### PR TITLE
allow metrics calculation on CPU

### DIFF
--- a/claragenomics/dl4atac/train/metrics.py
+++ b/claragenomics/dl4atac/train/metrics.py
@@ -20,7 +20,7 @@ class Metric(object):
         self.reset()
 
     def reset(self):
-        self.val = torch.tensor(0.).cuda()
+        self.val = torch.tensor(0.).cuda() if torch.cuda.is_available() else torch.tensor(0.)
 
     def get(self):
         return self.val


### PR DESCRIPTION
Got an error on trying to run calculate_baseline_metrics without GPU. Solved by allowing metrics initialization without `.cuda()`.