### PR TITLE
Fix typo in training

### DIFF
--- a/tutorials/tutorial1.md
+++ b/tutorials/tutorial1.md
@@ -178,7 +178,7 @@ Run step 7 as follows:
 python $atacworks/scripts/main.py train \
         --config configs/train_config.yaml \
         --config_mparams configs/model_structure.yaml \
-        --train_files <path to folder containing all h5 files for training> \
+        --files_train <path to folder containing all h5 files for training> \
         --val_files <path to folder containing all h5 files for validation>
 ```
 See Appendix 2 below for an example.


### PR DESCRIPTION
`train_files` has been changed to `files_train` to avoid argument parsing errors. train_files was being parsed as args.train, which is an already existing argument. This change is not reflected in the tutorial1. 