### PR TITLE
Always clone master branch in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN rsync -aP rsync://hgdownload.soe.ucsc.edu/genome/admin/exe/linux.x86_64/bedG
 RUN rsync -aP rsync://hgdownload.soe.ucsc.edu/genome/admin/exe/linux.x86_64/bigWigToBedGraph /usr/local/bin
 
 # Download AtacWorks repo
-RUN git clone --recursive https://github.com/clara-genomics/AtacWorks.git
+RUN git clone --recursive -b master https://github.com/clara-genomics/AtacWorks.git
 
 # Install AtacWorks requirements
 RUN pip3 install -r AtacWorks/requirements-base.txt && pip3 install -r AtacWorks/requirements-macs2.txt


### PR DESCRIPTION
Git is setup to clone our dev-* branch by default. In docker containers however, users should always be running on master branch. 