### PR TITLE
invalid_crossdevice_link

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -268,7 +268,7 @@ def writer(infer, intervals_file, exp_dir, result_fname,
             # Only one file should be left after the combiner stage
             assert (len(files) == 1)
             # move final files out of tmp folder
-            shutil.move(files[0], outfiles[channel])
+            shutil.copy(files[0], outfiles[channel])
 
     # remove tmp folder
     shutil.rmtree(temp_dir)


### PR DESCRIPTION
This PR addresses one of the issues being tracked in #153 . User is getting the following error when running atacworks inference:
```
Inference -------------------- [ 0/29]

Inference time taken:  120.692s (Load    3.292s,Prediction  117.140s)

INFO:2020-05-15 02:53:50,337:AtacWorks-main] Waiting for writer to finish...

Process Process-2:

Traceback (most recent call last):

  File "/usr/lib/python3.6/shutil.py", line 550, in move

    os.rename(src, real_dst)

OSError: [Errno 18] Invalid cross-device link:
'/tmp/247693.tmpdir/tmptkst0za1/0/00001' ->
'./inference_output_2020.05.15_02.51/NK_inferred.track.bedGraph'
```
Although it's not reproducible on our end, the error seems to be because `os.rename` and `shutile.move` fail when source and destinations seem to be on different file systems. 

An easy workaround for that is to use `shutil.copy` and os.remove`. Inspired from this thread : https://github.com/ewels/MultiQC/issues/806

-- Will wait for user to verify and report back that it works before merging. 