### PR TITLE
Fix batch size arg

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -273,6 +273,10 @@ def writer(infer, intervals_file, exp_dir,
                         files = sorted(
                             glob.glob(os.path.join(temp_dir,
                                                    str(channel), "*")))
+                        if len(files) == 0:
+                            _logger.debug("No files to combine")
+                            break
+
                         if len(files) == 1:
                             break
                         map_args = [(files[i * 2], files[i * 2 + 1])
@@ -426,7 +430,6 @@ def main():
                 args.interval_size = f['input'].shape[1] - 2 * args.pad
             else:
                 args.interval_size = f['input'].shape[1]
-            args.batch_size = 1
 
         ngpus_per_node = torch.cuda.device_count()
         # WAR: gloo distributed doesn't work if world size is 1.
@@ -518,7 +521,6 @@ def main():
                     args.interval_size = f['input'].shape[1] - 2 * args.pad
                 else:
                     args.interval_size = f['input'].shape[1]
-                args.batch_size = 1
 
             # Make sure that interval_size is a multiple of the out_resolution
             if args.out_resolution is not None:

--- a/tests/end-to-end/infer.sh
+++ b/tests/end-to-end/infer.sh
@@ -16,7 +16,7 @@ echo ""
 atacworks denoise \
     --out_home $out_dir --exp_name inference \
     --weights_path $expected_results_dir/model_latest/model_best.pth.tar \
-    --num_workers 0 --gpu_idx 0 \
+    --num_workers 4 --distributed \
     --noisybw $data_dir/HSC.5M.chr123.10mb.coverage.bw  \
     --regions "chr3" --interval_size 24000 \
     --genome $data_dir/example.sizes \


### PR DESCRIPTION
main.py had a stale code from v0.1 days, where it sets args.batch_size = 1. it didn't affect earlier, because this argument was not being used anywhere and batch size was set using args.bs argument. 

In the latest release, we changed the args.bs to args.batch_size and as a result, main.py always sets batch_size to 1 regardless of the input. 
Additionally, in the writer, a while loop only breaks if the number of files remaining in a folder are 1. As a result, while loop never breaks if there are 0 files to begin with. Added a condition to break the loop, if there are 0 files. 